### PR TITLE
fix: try again to publish

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 import os
 from setuptools import setup, find_namespace_packages
 
-
 with open(os.path.join("VERSION")) as f:
     version = f.read().strip()
 


### PR DESCRIPTION
BREAKING CHANGE maybe I shouldn't have rerun this tag version action after the pypi password secret was added https://github.com/opensafely/matching/runs/1643750967?check_suite_focus=true