### PR TITLE
feat: Load config from string or file as separate options

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ match:
 
 This matches 3 matches per case, on the variables `sex`, and `age` (±5 years) and produces output files in the default `.arrow` format.
 
-Note: the `config` parameter is a json string in the above example, but can also be a path to a json file.
+Note: the `config` parameter is a json string in the above example.  Config can also be provided as a path
+to a json file, using the `config-file` option.
 When the action runs, it only has access to files that are the outputs of previous actions. We can use a json
 file by writing it in a preceding action, e.g.
 
@@ -86,7 +87,7 @@ match:
     matching:[version]
     --cases output/cases.arrow
     --controls output/controls.arrow
-    --config output/config.json
+    --config-file output/config.json
   needs: [write_config, generate_cases, generate_controls]
   outputs:
     ...

--- a/justfile
+++ b/justfile
@@ -110,5 +110,5 @@ fix: devenv
 
 # Run the CLI tool with test data by default
 run cases="tests/test_data/fixtures/input_cases.csv" controls="tests/test_data/fixtures/input_controls.csv" config="tests/test_data/fixtures/config.json": devenv
-    $BIN/match --cases {{ cases }} --controls {{ controls }} --config {{ config }}
+    $BIN/match --cases {{ cases }} --controls {{ controls }} --config-file {{ config }}
     

--- a/project.yaml
+++ b/project.yaml
@@ -53,7 +53,7 @@ actions:
       python:v2 python -m osmatching.__main__
       --cases output/cases.arrow
       --controls output/controls.arrow
-      --config output/config.json
+      --config-file output/config.json
     needs: [write_config, generate_cases, generate_controls]
     outputs:
       highly_sensitive:


### PR DESCRIPTION
Having the config option take a file or a json string means that parsing it from the command line is unnecessarily complex, and the error messages can be confusing. We now require one of --config or --config-file.