### PR TITLE
Document use as python package and cli tool

### DIFF
--- a/EXTRA_DOCS.md
+++ b/EXTRA_DOCS.md
@@ -1,0 +1,95 @@
+# Using opensafely-matching
+
+## System requirements
+
+Requires Python 3.8+
+
+Install with:
+
+```
+pip install opensafely-matching
+```
+
+
+## Input data
+This is expected to be provided in two files in one of the supported formats (`.csv`, `.csv.gz` or `.arrow`) - one for the case/exposed group and one for the population to be matched.
+
+## Use
+
+### In a python script
+
+Matching is run by calling the match function with at least the required arguments, as per:
+```py
+from osmatching import match, load_config, load_dataframe
+
+config = load_config(
+    {
+        "matches_per_case": 3,
+        "index_date_variable": "index_date",
+        "match_variables": {
+            "sex": "category",
+            "age": 5
+        }
+    }
+)
+match(
+    case_df=load_dataframe("input_cases.arrow"),
+    match_df=load_dataframe("input_matches.arrow"),
+    match_config=load_config(config)
+)
+```
+
+
+This matches 3 matches per case, on the variables `sex`, and `age` (±5 years) and produces output files in the default `.arrow` format.\
+**Outputs:**\
+`output/matched_cases.arrow`\
+`output/matched_matches.arrow`\
+`output/matched_combined.arrow`\
+`output/matching_report.txt`
+
+
+### From the command line
+
+```sh
+usage: match [-h] (--config CONFIG | --config-file CONFIG) [--cases CASES]
+             [--controls CONTROLS] [--output-format {arrow,csv.gz,csv}]
+
+Matches cases to controls if provided with 2 datasets
+
+options:
+  -h, --help            show this help message and exit
+  --config CONFIG       The configuration for the matching action (a JSON string)
+  --config-file CONFIG  Path to the configuration JSON file for the matching action
+  --cases CASES         Data file that contains the cases
+  --controls CONTROLS   Data file that contains the cohort for cases
+  --output-format {arrow,csv.gz,csv}
+                        Format for the output files
+
+```
+
+To run the above example from the command line:
+```sh
+match --cases input_cases.arrow --controls input_matches.arrow --config-file config.json
+```
+where `config.json` is a file containing additional arguments to `match()`:
+```
+{
+  "matches_per_case": 3,
+  "match_variables": {
+    "sex": "category",
+    "age": 5
+  },
+  "index_date_variable": "indexdate"
+}
+```
+
+Alternatively, pass config on the command line as a json string:
+```sh
+match \
+  --cases input_cases.arrow \
+  --controls input_matches.arrow \
+  --config '{"matches_per_case": 3, "match_variables": {"sex": "category", "age": 5}, "index_date_variable": "indexdate"}'
+```
+
+
+For configuration options, please see the [reusable action documentation](README.md)

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ This action matches patients in one dataset file to a specified number of matche
 
 Input dataset files can be in `.csv`, `.csv.gz` or `.arrow` format.
 
+The documentation below refers to use of matching as a reusable action. To use the python package in a 
+python script or from the command line, please see the [alternative usage documentation](EXTRA_DOCS.md).
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
 > [!NOTE] 
-> The [`opensafely-matching` python package](https://pypi.org/project/opensafely-matching/) has been deprecated. If you are using this package
-> in an OpenSAFELY study, we recommend that you use the [matching reusable action](https://actions.opensafely.org/matching),
-> as documented below.
+> The [`opensafely-matching` python package](https://pypi.org/project/opensafely-matching/) is no
+> longer recommended for use in OpenSAFELY studies. We recommend that you use the 
+[matching reusable action](https://actions.opensafely.org/matching), as documented below.
 >
-> If you are using the python package, you can find the documentation for previous releases by
-> switching to the relevant tag in this repo. For example, [v1.0.0](https://github.com/opensafely-actions/matching/tree/v1.0.0).
+> The python package is still [available for use](EXTRA_DOCS.md) in python scripts or as a command line tool.
 
 
 # Matching: Simple categorical and scalar variable matching


### PR DESCRIPTION
Basically just copies the old cli/python script instructions and updates them to work with this version of the code.

See [slack thread](https://bennettoxford.slack.com/archives/C02HJTL065A/p1752072620931709)
We may want to reconsider the pypi package deprecation, and going back to autodeploying the package, but for now this just provides the missing docs 