### PR TITLE
fix: Add long description for pyPI package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,8 @@ setup(
     packages=find_namespace_packages(exclude=["tests"]),
     url="https://github.com/opensafely/matching",
     description="Command line tool for matching cases to controls",
+    long_description=open("EXTRA_DOCS.md").read(),
+    long_description_content_type="text/markdown",
     author="OpenSAFELY",
     license="GPLv3",
     author_email="tech@opensafely.org",


### PR DESCRIPTION
We're not automatically publishing to pyPI anymore, but there are users who still want to use the python package, so we want to publish manually every so often.  The last attempt [failed](https://github.com/opensafely-actions/matching/actions/runs/16596747773/job/46945181230#step:7:186), I _think_ because there's no long description (although I'm not sure why it worked previously).

This adds the cli/module docs as the long description (not the README, since that's reusable-action related)