### PR TITLE
Rename build-and-publish workflow

### DIFF
--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -1,4 +1,4 @@
-name: Tag repo; build and publish assets
+name: Build and publish python package
 on:
   # this allows us to trigger manually
   # Note: we are not automatically publishing to pypi anymore. This workflow is retained


### PR DESCRIPTION
To more accurately describe what it actually does.